### PR TITLE
Allow search by partial name

### DIFF
--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -3,7 +3,6 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**


### PR DESCRIPTION
Closes #52 

Prior to this pull request, when using the find command, the keyword had to be a full word rendering the function harder to use as individuals had to remember the full first/last name of a recruit before being able to search their contact up.

This PR seeks to resolve that by allowing a user to input a partial keyword (case-insensitive) of an individual's name (e.g. Jo to search for John) improving ease of use. 

The find command will be further enhanced to be search-able by phone/tag in future pull requests 