### PR TITLE
Improve edit command response message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -53,7 +53,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_RECRUIT = "This recruit already exists in the address book.";
     private static final String DELTA_FORMAT = " -> %s";
-    
+
     private final Index index;
     private final EditRecruitDescriptor editRecruitDescriptor;
 


### PR DESCRIPTION
The EditCommand result message is not showing the modification being made, that is, what is the old value and the new, modified value. Let's show the old value and the new value for a clearer feedback to the user to confirm that the modification was what was intended.

Closes #46 