### PR TITLE
Fix duplicate recruit creation bug

### DIFF
--- a/src/main/java/seedu/address/model/recruit/UniqueRecruitList.java
+++ b/src/main/java/seedu/address/model/recruit/UniqueRecruitList.java
@@ -34,7 +34,7 @@ public class UniqueRecruitList implements Iterable<Recruit> {
      */
     public boolean contains(Recruit toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::equals);
+        return internalList.stream().anyMatch(toCheck::isSameRecruit);
     }
 
     /**


### PR DESCRIPTION
This PR seeks to fix a bug reported during PE-D wherein two recruits with the exact same information could be added into the system. 

This has been fixed in this PR - Closes #334 